### PR TITLE
Feature: First-letter-lookups

### DIFF
--- a/src/services/AutocompleteProvider.js
+++ b/src/services/AutocompleteProvider.js
@@ -32,11 +32,19 @@ export default class AutocompleteProvider {
   getWords(fragment) {
     // Care must be taken to prevent arbitrary regexp from matching,
     //  so we test to see if it's comprised of normal english letter options in order to decide what test to use.
-    const isEnglish = REGEXP_ENGLISH.test(fragment);
-    return [...this.data.get(fragment[0])]
-    .filter((candidate) => isEnglish ? RegExp('^'+fragment, 'i').test(candidate[0]) : candidate[0].startsWith(fragment))
-    .sort(this.candidateSortFunction)
-    .slice(0, this.returnLimit);
+    if (fragment !== null
+      && typeof fragment === 'string'
+      && fragment.length > 0
+      && this.data.has(fragment[0].toLowerCase())
+    ) {
+        const isEnglish = REGEXP_ENGLISH.test(fragment);
+        return [...this.data.get(fragment[0].toLowerCase())]
+        .filter((candidate) => isEnglish ? RegExp('^'+fragment, 'i').test(candidate[0]) : candidate[0].startsWith(fragment))
+        .sort(this.candidateSortFunction)
+        .slice(0, this.returnLimit);
+    } else {
+      return [];
+    }
   }
 
   /**
@@ -48,15 +56,14 @@ export default class AutocompleteProvider {
       passage.toLowerCase().split(REGEXP_WHITESPACE_AND_PUNCTUATION)
       .forEach(
         (word) => {
-          if (!this.data.has(word[0])) {
+          if (!this.data.has(word[0]))
             this.data.set(word[0], new Map());
-          } else {
-            let section = this.data.get(word[0]);
-            if (section.has(word))
-              section.set(word, section.get(word) + 1);
-            else
-              section.set(word, 1);
-          }
+          let section = this.data.get(word[0]);
+          if (section.has(word))
+            section.set(word, section.get(word) + 1);
+          else
+            section.set(word, 1);
+          this.data.set(word[0] , section);
         }
       );
   }

--- a/src/services/AutocompleteProvider.js
+++ b/src/services/AutocompleteProvider.js
@@ -33,7 +33,7 @@ export default class AutocompleteProvider {
     // Care must be taken to prevent arbitrary regexp from matching,
     //  so we test to see if it's comprised of normal english letter options in order to decide what test to use.
     const isEnglish = REGEXP_ENGLISH.test(fragment);
-    return [...this.data]
+    return [...this.data.get(fragment[0])]
     .filter((candidate) => isEnglish ? RegExp('^'+fragment, 'i').test(candidate[0]) : candidate[0].startsWith(fragment))
     .sort(this.candidateSortFunction)
     .slice(0, this.returnLimit);
@@ -48,10 +48,15 @@ export default class AutocompleteProvider {
       passage.toLowerCase().split(REGEXP_WHITESPACE_AND_PUNCTUATION)
       .forEach(
         (word) => {
-          if (this.data.has(word))
-            this.data.set(word, this.data.get(word) + 1);
-          else
-            this.data.set(word, 1);
+          if (!this.data.has(word[0])) {
+            this.data.set(word[0], new Map());
+          } else {
+            let section = this.data.get(word[0]);
+            if (section.has(word))
+              section.set(word, section.get(word) + 1);
+            else
+              section.set(word, 1);
+          }
         }
       );
   }

--- a/tests/unit/services/AutocompleteProvider.spec.js
+++ b/tests/unit/services/AutocompleteProvider.spec.js
@@ -10,17 +10,17 @@ describe('AutocompleteProvider Service', () => {
     let acp = new AutocompleteProvider();
     acp.train('aardvark baboon camel');
     expect(acp.data.size).to.be.equal(3);
+    expect(acp.data.get('a').get('aardvark')).to.be.equal(1);
   });
 
   it('should keep count of trained word frequency', () => {
     let acp = new AutocompleteProvider();
     acp.train('aardvark aardvark camel');
     expect(acp.data.size).to.be.equal(2);
-    expect(acp.data.get('aardvark')).to.be.equal(2);
-    expect(acp.data.get('camel')).to.be.equal(1);
+    expect(acp.data.get('a').get('aardvark')).to.be.equal(2);
+    expect(acp.data.get('c').get('camel')).to.be.equal(1);
     acp.train('camel donkey diploticus');
-    expect(acp.data.get('camel')).to.be.equal(2);
-    expect(acp.data.size).to.be.equal(4);
+    expect(acp.data.get('c').get('camel')).to.be.equal(2);
   });
 
   it('should give no guesses if untrained', () => {


### PR DESCRIPTION
The original implementation was searching the entire datastore for autocomplete suggestions. Oops!

This breaks the datastore into discrete maps keyed by the first letter of a given trained word, which should speed up our lookup time.